### PR TITLE
Fix bug in ST create, fix documentation for ST

### DIFF
--- a/src/HPCCache/HPCCache/ChangeLog.md
+++ b/src/HPCCache/HPCCache/ChangeLog.md
@@ -18,6 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Fixed bug for New-AzHpcCacheStorageTarget and help text.
 
 ## Version 0.1.0
 * Preview of `Az.HPCCache` module

--- a/src/HPCCache/HPCCache/Commands/NewAzHpcStorageTarget.cs
+++ b/src/HPCCache/HPCCache/Commands/NewAzHpcStorageTarget.cs
@@ -130,7 +130,18 @@ namespace Microsoft.Azure.Commands.HPCCache
                 this.Name,
                 () =>
                 {
-                    this.storageTarget = this.CLFS.IsPresent ? this.CreateClfsStorageTargetParameters() : this.CreateNfsStorageTargetParameters();
+                    if (this.CLFS.IsPresent)
+                    {
+                        this.storageTarget = this.CreateClfsStorageTargetParameters();
+                    }
+                    else if (this.NFS.IsPresent)
+                    {
+                        this.storageTarget = this.CreateNfsStorageTargetParameters();
+                    }
+                    else
+                    {
+                        throw new Exception(string.Format(Resources.CLFSorNFS));
+                    }
                     if (this.IsParameterBound(c => c.Junction))
                     {
                         this.storageTarget.Junctions = new List<NamespaceJunction>();
@@ -170,7 +181,7 @@ namespace Microsoft.Azure.Commands.HPCCache
                     this.CacheName,
                     this.Name);
 
-                throw new Exception(string.Format(Resources.UpgradeHpcCache, this.Name, this.CacheName));
+                throw new Exception(string.Format(Resources.StorageTargetAlreadyExist, this.Name, this.CacheName));
             }
             catch (CloudErrorException e)
             {

--- a/src/HPCCache/HPCCache/Properties/Resources.Designer.cs
+++ b/src/HPCCache/HPCCache/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Azure.Commands.HPCCache.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Need CLFS or NFS flag..
+        /// </summary>
+        internal static string CLFSorNFS {
+            get {
+                return ResourceManager.GetString("CLFSorNFS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to create HPC cache storage target &apos;{0}&apos;?.
         /// </summary>
         internal static string ConfirmCreateStorageTarget {

--- a/src/HPCCache/HPCCache/Properties/Resources.resx
+++ b/src/HPCCache/HPCCache/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CLFSorNFS" xml:space="preserve">
+    <value>Need CLFS or NFS flag.</value>
+  </data>
   <data name="ConfirmCreateStorageTarget" xml:space="preserve">
     <value>Are you sure you want to create HPC cache storage target '{0}'?</value>
   </data>

--- a/src/HPCCache/HPCCache/help/New-AzHpcCacheStorageTarget.md
+++ b/src/HPCCache/HPCCache/help/New-AzHpcCacheStorageTarget.md
@@ -33,12 +33,12 @@ The **New-AzHpcCacheStorageTarget** cmdlet adds a Storage Target to Azure HPC Ca
 
 ### Example 1
 ```powershell
-PS C:\> New-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -CLFS -StorageContainerID "/subscriptions/testsub/resourceGroups/testRG/providers/Microsoft.Storage/storageAccounts/testdstorageaccount/blobServices/default/containers/testcontainer" -Junctions @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/"})
+PS C:\> New-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -CLFS -StorageContainerID "/subscriptions/testsub/resourceGroups/testRG/providers/Microsoft.Storage/storageAccounts/testdstorageaccount/blobServices/default/containers/testcontainer" -Junction @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/"})
 ```
 
 ### Example 2
 ```powershell
-PS C:\> New-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -NFS -UsageModel "READ_HEAVY_INFREQ" -Junctions @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/"})
+PS C:\> New-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -NFS -UsageModel "READ_HEAVY_INFREQ" -Junction @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/"})
 ```
 
 ## PARAMETERS

--- a/src/HPCCache/HPCCache/help/Set-AzHpcCacheStorageTarget.md
+++ b/src/HPCCache/HPCCache/help/Set-AzHpcCacheStorageTarget.md
@@ -33,12 +33,12 @@ The **Set-AzHpcCacheStorageTarget** cmdlet updates a Storage Target attached to 
 
 ### Example 1
 ```powershell
-PS C:\> Set-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -CLFS -Junctions @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/"})
+PS C:\> Set-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -CLFS -Junction @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/"})
 ```
 
 ### Example 2
 ```powershell
-PS C:\> Set-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -NFS -Junctions @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/export"})
+PS C:\> Set-AzHpcCacheStorageTarget -ResourceGroupName testRG -CacheName testCache -StorageTargetName testST -NFS -Junction @(@{"namespacePath"="/msazure";"targetPath"="/";"nfsExport"="/export"})
 ```
 
 ## PARAMETERS


### PR DESCRIPTION


Without Flag:
```
PS C:\Users\remakar\azure-powershell-pr\artifacts\Debug\Az.HPCCache> New-AzHpcCacheStorageTarget -ResourceGroupName test_rg -CacheName test_cmdlet_cache -Name test_cmdlet_st  -StorageContainerID "<ID>" -Junction @(@{"namespacePath"="/cache/storage/targets/test_cmdlet_st";"targetPath"="/"})

Confirm
Are you sure you want to create HPC cache storage target 'test_cmdlet_st'?
[Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): Y
New-AzHpcCacheStorageTarget : Need CLFS or NFS flag.
At line:1 char:1
+ New-AzHpcCacheStorageTarget -ResourceGroupName test_rg -CacheNam ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : CloseError: (:) [New-AzHpcCacheStorageTarget], Exception
+ FullyQualifiedErrorId : Microsoft.Azure.Commands.HPCCache.NewAzHpcStorageTarget

```

With Wrong flag (NFS FLAG ON CLFS ST): 
```
PS C:\Users\remakar\azure-powershell-pr\artifacts\Debug\Az.HPCCache> New-AzHpcCacheStorageTarget -ResourceGroupName test_rg -NFS -CacheName test_cmdlet_cache -Name test_cmdlet_st  -StorageContainerID "<ID>" -Junction @(@{"namespacePath"="/cache/storage/targets/test_cmdlet_st";"targetPath"="/"})
New-AzHpcCacheStorageTarget : Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided.
At line:1 char:1
+ New-AzHpcCacheStorageTarget -ResourceGroupName test_rg -NFS -Cac ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidArgument: (:) [New-AzHpcCacheStorageTarget], ParameterBindingException
+ FullyQualifiedErrorId : AmbiguousParameterSet,Microsoft.Azure.Commands.HPCCache.NewAzHpcStorageTarget
```

With correct (-CLFS):

```
PS C:\Users\remakar\azure-powershell-pr\artifacts\Debug\Az.HPCCache> New-AzHpcCacheStorageTarget -ResourceGroupName test_rg -CacheName test_cmdlet_cache -Name test_cmdlet_st123 -CLFS -StorageContainerID "<ID>" -Junction @(@{"namespacePath"="/cache";"targetPath"="/"})

Confirm
Are you sure you want to create HPC cache storage target 'test_cmdlet_st123'?
[Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): Y

Name              : test_cmdlet_st123
Id                : <ID>
TargetType        : clfs
ProvisioningState : Creating
Junctions         : {Microsoft.Azure.PowerShell.Cmdlets.HPCCache.Models.PSNamespaceJunction}
Nfs3              :
Clfs              : Microsoft.Azure.PowerShell.Cmdlets.HPCCache.Models.PSHpcClfsTarget
```

In new-azhpccachestoragetarget it was throwing the wrong exception if the storage target already exists, it was throwing upgradeCache instead of storageTargetAlreadyExists.

Fix examples in help files. -Junction instead of -Junctions 

```
Confirm
Are you sure you want to create HPC cache storage target 'test_cmdlet_st'?
[Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): Y
New-AzHpcCacheStorageTarget : The storage target 'test_cmdlet_st' already exists for HPC cache 'test_cmdlet_st'.
At line:1 char:1
+ New-AzHpcCacheStorageTarget -ResourceGroupName test_rg -CacheNam ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : CloseError: (:) [New-AzHpcCacheStorageTarget], Exception
+ FullyQualifiedErrorId : Microsoft.Azure.Commands.HPCCache.NewAzHpcStorageTarget
```